### PR TITLE
Fix/docker-build: Migrate to Micromamba to resolve dependency errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,112 +3,122 @@ FROM python:3.11-slim AS build
 
 ## Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
-# setup python virtual environment
-ENV PATH="/opt/venv/bin:$PATH"
 
 # Set a working directory for building
 WORKDIR /opt/PDBCharges
 
 # Install system dependencies for building
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    cmake \
-    wget \
-    curl \
-    gfortran \
-    git \
-    libopenblas-dev \
-    liblapack-dev \
-    libeigen3-dev \
-    libx11-dev \
-    libglu1-mesa-dev \
-    libxi-dev \
-    libxrandr-dev \
-    libxcursor-dev \
-    libxtst-dev \
-    zlib1g-dev \
-    openbabel=3.1.1+dfsg-9+b3
+  build-essential \
+  cmake \
+  wget \
+  curl \
+  gfortran \
+  git \
+  libopenblas-dev \
+  liblapack-dev \
+  libeigen3-dev \
+  libx11-dev \
+  libglu1-mesa-dev \
+  libxi-dev \
+  libxrandr-dev \
+  libxcursor-dev \
+  libxtst-dev \
+  zlib1g-dev \
+  openbabel \
+  && rm -rf /var/lib/apt/lists/*
 
-# Set up python virtual environment
-RUN python3 -m venv /opt/venv
+ENV MAMBA_ROOT_PREFIX=/opt/conda
+ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
 
-# Install xtb 6.6.1
-RUN curl -L https://github.com/grimme-lab/xtb/releases/download/v6.6.1/xtb-6.6.1-source.tar.xz | tar xJ \
-    && cd xtb-6.6.1 \
-    && mkdir build && cd build \
-    && cmake .. \
-    && make -j$(nproc) \
-    && make install \
-    && cd ../.. && rm -rf xtb-6.6.1
+# Download and install Micromamba
+RUN curl -L https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba && \
+  mkdir -p /opt/conda/pkgs
+
+# We install python, rdkit, pandas, dimorphite-dl, and libstdcxx-ng
+RUN ./bin/micromamba create -y -p /opt/conda/envs/base -c conda-forge \
+  python=3.11 \
+  rdkit=2023.09.6 \
+  openmm=8.2.0 \
+  pandas \
+  dimorphite-dl=1.3.2 \
+  libstdcxx-ng \
+  && rm -rf /root/.cache bin/micromamba
+
+# Activate the Conda environment
+# This ensures that 'pip' and 'python' commands below use the Conda env.
+ENV PATH="/opt/conda/envs/base/bin:$PATH"
 
 # Install Python dependencies
 RUN pip install --no-cache-dir \
-    dimorphite_dl==1.3.2 \
-    hydride==1.2.3 \
-    biopython==1.84 \
-    numpy==1.26.4 \
-    biotite==1.0.1 \
-    gemmi==0.6.6 \
-    rdkit==2023.09.6 \
-    moleculekit==1.9.15 \
-    pdb2pqr==3.6.1 \
-    openmm==8.2.0
+  hydride==1.2.3 \
+  biopython==1.84 \
+  numpy==1.26.4 \
+  biotite==1.0.1 \
+  gemmi==0.6.6 \
+  moleculekit==1.9.15 \
+  pdb2pqr==3.6.1
+
+# Install xtb 6.6.1
+RUN curl -L https://github.com/grimme-lab/xtb/releases/download/v6.6.1/xtb-6.6.1-source.tar.xz | tar xJ \
+  && cd xtb-6.6.1 \
+  && mkdir build && cd build \
+  && cmake .. \
+  && make -j$(nproc) \
+  && make install \
+  && cd ../.. && rm -rf xtb-6.6.1
 
 # Install pdbfixer
 RUN git clone https://github.com/openmm/pdbfixer.git /opt/pdbfixer \
-    && cd /opt/pdbfixer \
-    && git config --global advice.detachedHead false \
-    && git checkout c83d125f445d3cea414203d48e4438c6033aaec6 \
-    && pip install .
+  && cd /opt/pdbfixer \
+  && git config --global advice.detachedHead false \
+  && git checkout c83d125f445d3cea414203d48e4438c6033aaec6 \
+  && pip install . \
+  && cd / && rm -rf /opt/pdbfixer
 
-## Get sources
+# Get sources
 COPY calculate_charges_workflow.py .
 COPY phases phases
 COPY docker docker
 
-# Edit preparation.py file from moleculekit lib
-RUN python3 docker/edit_moleculekit.py /opt/venv/lib/python3.11/site-packages/moleculekit/tools/preparation.py
+# Apply modifications to moleculekit (Using the Conda path)
+RUN python3 docker/edit_moleculekit.py /opt/conda/envs/base/lib/python3.11/site-packages/moleculekit/tools/preparation.py
 
 ### Stage 2: Runtime stage
 FROM python:3.11-slim AS runtime
 
-## Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PATH="/opt/PDBCharges:/home/user/.local/bin:${PATH}"
-# Use prepared python environment
-ENV PATH="/opt/venv/bin:$PATH"
+
+# Set PATH to prefer Conda bin. 
+ENV PATH="/opt/PDBCharges:/opt/conda/envs/base/bin:$PATH"
+
+# Set LD_LIBRARY_PATH so system tools can find Conda's C++ libraries
+ENV LD_LIBRARY_PATH="/opt/conda/envs/base/lib:$LD_LIBRARY_PATH"
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libopenblas-dev \
-    gfortran \
-    nano \
-    wget \
-    procps \
-    openbabel=3.1.1+dfsg-9+b3 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  libopenblas0 \
+  libgfortran5 \
+  openbabel \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-## Copy artefacts from build container
-# Python libs
-COPY --from=build /opt/venv /opt/venv
-# xtb
+## Copy artefacts
+COPY --from=build /opt/conda /opt/conda
 COPY --from=build /usr/local/bin/xtb /usr/local/bin/
 COPY --from=build /usr/local/lib/libxtb.so* /usr/local/lib/
 COPY --from=build /usr/local/share/xtb /usr/local/share/xtb
-# PDBCharges
 COPY --from=build /opt/PDBCharges /opt/PDBCharges
 
-# Set working directory
+# Set the working directory
 WORKDIR /opt/PDBCharges
 
-# Create a non-root user and change ownership
+# Create a user and set permissions
 RUN useradd --create-home --shell /bin/bash user \
-    && chown -R user:user /opt \
-    && chmod u+x calculate_charges_workflow.py
+  && chown -R user:user /opt \
+  && chmod u+x calculate_charges_workflow.py
 
-# Switch to the non-root user
+# Switch to the user
 USER user
 
-# Set default command
-CMD ["python3", "calculate_charges_workflow.py"]
+CMD ["python", "calculate_charges_workflow.py"]


### PR DESCRIPTION
# Description
This PR fixes the Docker build failure caused by dimorphite_dl==1.3.2 being unavailable on PyPI.

To address this, the Dockerfile has been refactored to use Micromamba instead of a standard Python virtual environment.

# Key Changes

- **Dependency Management**: Switched from venv to micromamba.
- **Package Source**: dimorphite_dl==1.3.2, rdkit, and openmm are now installed via conda-forge, where version 1.3.2 is still available.
- **Path Updates**: Updated the edit_moleculekit.py script path and LD_LIBRARY_PATH to point to the new Conda environment locations.

# Reasoning
The build was failing with: ERROR: Could not find a version that satisfies the requirement dimorphite_dl==1.3.2. Since the PyPI release for this specific version appears to have been removed or deprecated, switching to Conda-forge allows us to keep the version pinned as required by the workflow without introducing breaking changes. Upgrading dimorphite_dl would create additional problems because the newer versions include API changes that require code modifications.

# Verification
- [x] Docker build completes successfully locally.
- [x] Program completes a partial charge calculation for 1alf

# Closes
This PR closes issue #6 
